### PR TITLE
Update setup-dev.sh to properly set the before_script depending on the machine architecture

### DIFF
--- a/MagicCP.cabal
+++ b/MagicCP.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5e2ff13654219dab0d6212f685c68dad2df96c4a1550d40be3f107a041599332
+-- hash: df9cca307b1107b23267cb8f7ac4397dc128109fa765c79e570426d213ad6fa1
 
 name:           MagicCP
 version:        0.0.0
@@ -50,7 +50,6 @@ library
     , template-haskell
     , text
     , time
-    , unix
     , xml-conduit
   default-language: Haskell2010
 
@@ -82,6 +81,5 @@ executable MagicCP
     , template-haskell
     , text
     , time
-    , unix
     , xml-conduit
   default-language: Haskell2010

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ corre el siguiente comando:
 ./setup-dev.sh
 ```
 
+# Ejecucion
+
 Para correr el proyecto, ejecute el siguiente comando:
 
 ```bash
 stack run -- MagicCP
 ```
-

--- a/package.yaml
+++ b/package.yaml
@@ -35,7 +35,6 @@ dependencies:
 - time
 - text
 - text
-- unix
 - xml-conduit
 - split
 - containers

--- a/src/MagicCP.hs
+++ b/src/MagicCP.hs
@@ -7,14 +7,18 @@ module MagicCP where
 
 import qualified Language.Haskell.TH as TH
 
-import Data.Map (Map)
 import CF                       (ProblemId)
 import CF.CFConfig              (CFConfig (..))
 import CF.CFToolWrapper         (Verdict (..))
 import Control.Concurrent       (ThreadId)
 import Control.Exception        (SomeException (..), catch)
 import Data.Generics            (Data)
-import MagicCP.ParseInputOutput (ParseInputOutput, WithTestCases (..), Predicate(..))
+import Data.Map                 (Map)
+import MagicCP.ParseInputOutput
+    ( ParseInputOutput
+    , Predicate (..)
+    , WithTestCases (..)
+    )
 import MagicCP.SearchOptions    (WithAbsents (..), WithOptimizations (..))
 import MagicHaskeller.LibTH
     ( Exp (..)
@@ -41,6 +45,7 @@ import qualified Data.Array                      as Array
 import qualified Data.Char
 import qualified Data.Generics
 import qualified Data.List                       as List
+import qualified Data.Map                        as Map
 import qualified Data.Maybe                      as Maybe
 import qualified Data.Time.Clock                 as Clock
 import qualified Debug.Trace
@@ -54,7 +59,6 @@ import qualified MagicHaskeller.LibTHDefinitions as LibTHDefinitions
 import qualified MagicHaskeller.ProgramGenerator as ProgramGenerator
 import qualified MagicHaskeller.TimeOut          as TimeOut
 import qualified Text.Printf                     as Printf
-import qualified Data.Map as Map
 
 checkInitialized :: IO ()
 checkInitialized = do

--- a/src/MagicCP/ParseInputOutput.hs
+++ b/src/MagicCP/ParseInputOutput.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE NamedFieldPuns      #-}
 
 module MagicCP.ParseInputOutput where
 
+import Data.Map            (Map)
 import Language.Haskell.TH (DecsQ)
-import Data.Map (Map)
 
 import qualified Control.Monad
+import qualified Data.Map                  as Map
+import qualified Data.Maybe
 import qualified MagicCP.ParserDefinitions as ParserDefinitions
 import qualified Text.Read
-import qualified Data.Maybe
-import qualified Data.Map as Map
 
 (&&&) :: Predicate b -> Predicate b -> Predicate b
 Predicate {predicateFun = p1, ..} &&& Predicate {predicateFun = p2} =


### PR DESCRIPTION
This PR updates the setup-dev.sh to properly configure the cf-tool configuration file to wrap the GHC execution over `arch -arm64`. This way, we don't get nasty errors related to LLVM not finding symbols in x86_64 architecture (even though GHC may natively run in arm64)

In addition, the `unix` dependency was removed, as it was not necessary to keep using it.